### PR TITLE
Update gpt4 model

### DIFF
--- a/dragula.py
+++ b/dragula.py
@@ -112,7 +112,7 @@ class Dragula:
         response_query_chain = (
             {"context": passage_retriever, "question": RunnablePassthrough()}
             | response_query_prompt
-            | ChatOpenAI(model_name="gpt-4")
+            | ChatOpenAI(model_name="gpt-4-1106-preview")
             | StrOutputParser()
         )
 


### PR DESCRIPTION
The project is currently set to use the `gpt-4` model to generate the final response. The new GPT 4 Turbo model is [more capable and cheaper](https://help.openai.com/en/articles/8555510-gpt-4-turbo), so let's use that instead.